### PR TITLE
Implement support for more terse name syntax

### DIFF
--- a/data/lecture5.sdl
+++ b/data/lecture5.sdl
@@ -40,8 +40,7 @@ Scene {
 
         // Plane:
 
-        Plane {
-            name 		"floor"
+        Plane "floor" {
             y			-0.01
         }
 

--- a/source/rt/exception.d
+++ b/source/rt/exception.d
@@ -48,11 +48,9 @@ class EntityWithDuplicateName : InvalidSceneException
 {
     @safe pure
     this(string entityName,
-         string msg = null,
-         Throwable next = null,
          string file = __FILE__, size_t line = __LINE__)
     {
-        msg = msg? msg : format("An entity named %s is already present!", entityName);
+        msg = format("An entity named %s is already present!", entityName);
         super(msg, next, file, line);
     }
 }


### PR DESCRIPTION
Now scene entities can use the following syntax:

```
Plane "floor" {
    y       -0.01
}

```

in addition to the longer, previously only supported syntax:

```
Plane {
    name    "floor"
    y       -0.01
}

```
